### PR TITLE
Add site-wide login & alt-template options

### DIFF
--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -80,6 +80,24 @@ form:
               validate:
                 type: bool
 
+            alt_extend.enabled:
+              type: toggle
+              label: PLUGIN_LOGIN.ALT_EXTEND
+              highlight: 1
+              default: 0
+              help: PLUGIN_LOGIN.ALT_EXTEND_HELP
+              options:
+                1: PLUGIN_ADMIN.ENABLED
+                0: PLUGIN_ADMIN.DISABLED
+              validate:
+                type: bool
+
+            alt_extend.template:
+              type: text
+              label: PLUGIN_LOGIN.ALT_EXTEND_TEMPLATE
+              default: partials/login-plain.html.twig
+              help: PLUGIN_LOGIN.ALT_EXTEND_TEMPLATE_HELP
+
             rememberme:
               type: section
               title: PLUGIN_LOGIN.REMEMBER_ME
@@ -111,6 +129,29 @@ form:
                   size: small
                   label: PLUGIN_ADMIN.NAME
                   help: PLUGIN_ADMIN.SESSION_NAME_HELP
+
+            site_wide:
+              type: section
+              title: PLUGIN_LOGIN.SITE_WIDE
+
+              fields:
+                site_wide.enabled:
+                  type: toggle
+                  label: PLUGIN_LOGIN.SITE_WIDE_ENABLED
+                  highlight: 1
+                  default: 0
+                  help: PLUGIN_LOGIN.SITE_WIDE_ENABLED_HELP
+                  options:
+                    1: PLUGIN_ADMIN.ENABLED
+                    0: PLUGIN_ADMIN.DISABLED
+                  validate:
+                    type: bool
+
+                site_wide.acl:
+                  type: text
+                  label: PLUGIN_LOGIN.SITE_WIDE_ACL
+                  default: site.login
+                  help: PLUGIN_LOGIN.SITE_WIDE_ACL_HELP
 
         registration:
           type: tab

--- a/css/login.css
+++ b/css/login.css
@@ -1,3 +1,13 @@
+@import url(//fonts.googleapis.com/css?family=Montserrat:400|Raleway:300,400,600|Inconsolata);
+
+*, *::before, *::after {
+    -webkit-box-sizing: border-box;
+    -moz-box-sizing: border-box;
+    box-sizing: border-box;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+}
+
 #grav-login {
     max-width: 30rem;
     margin: 5rem auto;
@@ -6,6 +16,8 @@
     border-radius: 4px;
     padding: 1rem 3rem 3rem 3rem;
     text-align: center;
+    font-family: "Raleway", "Helvetica", "Tahoma", "Geneva", "Arial", sans-serif;
+    line-height: 1.7;
 }
 
 #grav-login .form-actions {
@@ -18,7 +30,7 @@
     right: 5px;
 }
 
-.alert.info {
+#grav-login .error {
     color: #c00;
 }
 
@@ -28,12 +40,74 @@
     padding: 0;
     text-align: center;
 }
+
+#grav-login h1 {
+    font-size: 3.2rem;
+    text-align: center;
+    letter-spacing: -3px;
+}
+
+#grav-login h1, h2, h3, h4, h5, h6 {
+    font-family: "Montserrat", "Helvetica", "Tahoma", "Geneva", "Arial", sans-serif;
+    font-weight: 400;
+    margin: 0.85rem 0 1.7rem 0;
+    text-rendering: optimizeLegibility;
+}
+
+#grav-login input[type="checkbox"] {
+    box-sizing: border-box;
+    padding: 0;
+    display: inline;
+    margin-right: 0.425rem;
+    width: auto;
+}
+
+#grav-login input {
+    color: inherit;
+    font: inherit;
+    -webkit-transition: border-color;
+    -moz-transition: border-color;
+    transition: border-color;
+    border-radius: 0.1875rem;
+    margin-bottom: 0.85rem;
+    padding: 0.425rem 0.425rem;
+    border: 1px solid #ddd;
+    box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.06);
+    line-height: normal;
+    width: 100%;
+}
+
+#grav-login label {
+    font-weight: 600;
+}
+
 #grav-login .form-actions p {
     margin-bottom: 0;
 }
 
 #grav-login .button {
     vertical-align: middle;
+    background: #fff;
+    color: #1BB3E9;
+    border: 1px solid #1BB3E9;
+    border-radius: 3px;
+    font-family: "Raleway", "Helvetica", "Tahoma", "Geneva", "Arial", sans-serif;
+    line-height: 1.7;
+    font-size: inherit;
+    font-variant: inherit;
+    font-weight: inherit;
+    display: inline-block;
+    padding: 7px 20px;
+    text-decoration: none;
+    text-align: center;
+}
+
+#grav-login .button:hover {
+    background: #1BB3E9;
+    color: #fff;
+}
+#grav-login .button:active {
+    box-shadow: 0 1px 0 #118ab5;
 }
 
 #grav-login .delimiter {
@@ -74,4 +148,5 @@
 #grav-login .rememberme label {
     font-weight: inherit;
     display: inline;
+    margin-bottom: 0.425rem;
 }

--- a/languages.yaml
+++ b/languages.yaml
@@ -66,6 +66,15 @@ en:
     TIMEOUT_HELP: "Sets the session timeout in seconds when Remember Me is enabled and checked by the user. Minimum is 604800 which means 1 week"
     GROUPS_HELP: "List of groups the new registered user will be part of, if any"
     SITE_ACCESS_HELP: "List of site access levels the new registered user will have. Example: `login` -> `true` "
+    ALT_EXTEND: "Display login form only"
+    ALT_EXTEND_HELP: "Remove theme blocks like menus and footers on login screen"
+    ALT_EXTEND_TEMPLATE: "Template to extend for login-form"
+    ALT_EXTEND_TEMPLATE_HELP: "Template to use instead of partials/base.html.twig"
+    SITE_WIDE: "Site-Wide Login"
+    SITE_WIDE_ENABLED: "Require login on all pages"
+    SITE_WIDE_ENABLED_HELP: "Keep your entire private regardless of per-page or parent ACL"
+    SITE_WIDE_ACL: "Default ACL site-wide"
+    SITE_WIDE_ACL_HELP: "This ACL will be added to all pages"
 
 fr:
   PLUGIN_LOGIN:

--- a/login.php
+++ b/login.php
@@ -418,7 +418,7 @@ class LoginPlugin extends Plugin
         }
 
         // If site-wide ACL is enabled, require login
-        if ($config->get('site_wide.enabled')) {
+        if ($config->get('site_wide.enabled') && !$rules) {
             $rules[$config->get('site_wide.acl')] = true;
         }
 

--- a/login.php
+++ b/login.php
@@ -417,6 +417,11 @@ class LoginPlugin extends Plugin
             }
         }
 
+        // If site-wide ACL is enabled, require login
+        if ($config->get('site_wide.enabled')) {
+            $rules[$config->get('site_wide.acl')] = true;
+        }
+
         // Continue to the page if it has no ACL rules.
         if (!$rules) {
             return;

--- a/login.yaml
+++ b/login.yaml
@@ -34,3 +34,11 @@ rememberme:
   enabled: true
   timeout: 1800                        # Timeout in seconds
   name: grav-rememberme                # Name prefix of the session cookie
+
+alt_extend:
+  enabled: false
+  template: 'partials/login-base.html.twig'
+
+site_wide:
+  enabled: false
+  acl: 'site.login'

--- a/templates/login.html.twig
+++ b/templates/login.html.twig
@@ -1,4 +1,4 @@
-{% extends 'partials/base.html.twig' %}
+{% extends config.plugins.login.alt_extend.enabled ? config.plugins.login.alt_extend.template : 'partials/base.html.twig' %}
 
 {% block content %}
     {% include 'partials/login-form.html.twig' %}

--- a/templates/partials/login-base.html.twig
+++ b/templates/partials/login-base.html.twig
@@ -1,0 +1,36 @@
+{% set theme_config = attribute(config.themes, config.system.pages.theme) %}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    {% block head %}
+        <meta charset="utf-8" />
+        <title>{% if header.title %}{{ header.title }} | {% endif %}{{ site.title }}</title>
+        <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" />
+        <link rel="alternate" type="application/atom+xml" href="{{ base_url_absolute}}/feed:atom" title="Atom Feed" />
+        <link rel="alternate" type="application/rss+xml" href="{{ base_url_absolute}}/feed:rss" title="RSS Feed" />
+        <link rel="icon" type="image/png" href="{{ url('theme://images/favicon.png') }}">
+
+        {% block stylesheets %}
+            {% do assets.addCss('theme://css/font-awesome.css',100) %}
+            {% do assets.addCss('theme://css/font-awesome.min.css',100) %}
+
+            {{ assets.css() }}
+        {% endblock %}
+
+        {% block javascripts %}
+            {{ assets.js() }}
+        {% endblock %}
+
+    {% endblock %}
+</head>
+
+<body>
+{% block content %}
+{% endblock %}
+{% block analytics %}
+    {% if theme_config.google_analytics_code %}
+        {% include 'partials/analytics.html.twig' %}
+    {% endif %}
+{% endblock %}
+</body>
+</html>


### PR DESCRIPTION
I wanted to use the Learn2 template for some internal client documentation, so I came up with this. It would solve issue #4 without having to use the other plugin that uses sha1 hashes. 

I might have gotten a little carried away, but the alt-template option was added for an easy fix for things like #46. It would also give themes an easier way to support a built-in login template. The CSS I added to remove theme dependencies, ends up looking better with both the alt-template enabled or disabled. 

Let me know what you think