### PR TITLE
Point account path to core's account stream

### DIFF
--- a/classes/Login.php
+++ b/classes/Login.php
@@ -155,7 +155,7 @@ class Login
         }
 
         $username = $data['username'];
-        $file = CompiledYamlFile::instance($this->grav['locator']->findResource('user://accounts/' . $username . YAML_EXT,
+        $file = CompiledYamlFile::instance($this->grav['locator']->findResource('account://' . $username . YAML_EXT,
             true, true));
 
         // Create user object and save it

--- a/cli/ChangePasswordCommand.php
+++ b/cli/ChangePasswordCommand.php
@@ -97,7 +97,7 @@ class ChangePasswordCommand extends ConsoleCommand
         $username = strtolower($username);
         
         // Grab the account file and read in the information before setting the file (prevent setting erase)
-        $oldUserFile = CompiledYamlFile::instance(self::getGrav()['locator']->findResource('user://accounts/' . $username . YAML_EXT, true, true));
+        $oldUserFile = CompiledYamlFile::instance(self::getGrav()['locator']->findResource('account://' . $username . YAML_EXT, true, true));
         $oldData = $oldUserFile->content();
         
         //Set the password feild to new password
@@ -105,7 +105,7 @@ class ChangePasswordCommand extends ConsoleCommand
         
         // Create user object and save it using oldData (with updated password)
         $user = new User($oldData);
-        $file = CompiledYamlFile::instance(self::getGrav()['locator']->findResource('user://accounts/' . $username . YAML_EXT, true, true));
+        $file = CompiledYamlFile::instance(self::getGrav()['locator']->findResource('account://' . $username . YAML_EXT, true, true));
         $user->file($file);
         $user->save();
 
@@ -137,7 +137,7 @@ class ChangePasswordCommand extends ConsoleCommand
                 if (!preg_match('/^[a-z0-9_-]{3,16}$/', $value)) {
                     throw new \RuntimeException('Username should be between 3 and 16 characters, including lowercase letters, numbers, underscores, and hyphens. Uppercase letters, spaces, and special characters are not allowed');
                 }
-                if (!file_exists(self::getGrav()['locator']->findResource('user://accounts/' . $value . YAML_EXT))) {
+                if (!file_exists(self::getGrav()['locator']->findResource('account://' . $value . YAML_EXT))) {
                     throw new \RuntimeException('Username "' . $value . '" does not exist, please pick another username');
                 }
 

--- a/cli/ChangeUserStateCommand.php
+++ b/cli/ChangeUserStateCommand.php
@@ -96,7 +96,7 @@ class ChangeUserStateCommand extends ConsoleCommand
         $username = strtolower($username);
 
         // Grab the account file and read in the information before setting the file (prevent setting erase)
-        $oldUserFile = CompiledYamlFile::instance(self::getGrav()['locator']->findResource('user://accounts/' . $username . YAML_EXT, true, true));
+        $oldUserFile = CompiledYamlFile::instance(self::getGrav()['locator']->findResource('account://' . $username . YAML_EXT, true, true));
         $oldData = $oldUserFile->content();
         
         //Set the state feild to new state
@@ -104,7 +104,7 @@ class ChangeUserStateCommand extends ConsoleCommand
         
         // Create user object and save it using oldData (with updated state)
         $user = new User($oldData);
-        $file = CompiledYamlFile::instance(self::getGrav()['locator']->findResource('user://accounts/' . $username . YAML_EXT, true, true));
+        $file = CompiledYamlFile::instance(self::getGrav()['locator']->findResource('account://' . $username . YAML_EXT, true, true));
         $user->file($file);
         $user->save();
 
@@ -136,7 +136,7 @@ class ChangeUserStateCommand extends ConsoleCommand
                 if (!preg_match('/^[a-z0-9_-]{3,16}$/', $value)) {
                     throw new \RuntimeException('Username should be between 3 and 16 characters, including lowercase letters, numbers, underscores, and hyphens. Uppercase letters, spaces, and special characters are not allowed');
                 }
-                if (!file_exists(self::getGrav()['locator']->findResource('user://accounts/' . $value . YAML_EXT))) {
+                if (!file_exists(self::getGrav()['locator']->findResource('account://' . $value . YAML_EXT))) {
                     throw new \RuntimeException('Username "' . $value . '" does not exist, please pick another username');
                 }
 

--- a/cli/NewUserCommand.php
+++ b/cli/NewUserCommand.php
@@ -208,7 +208,7 @@ class NewUserCommand extends ConsoleCommand
 
         // Create user object and save it
         $user = new User($data);
-        $file = CompiledYamlFile::instance(Grav::instance()['locator']->findResource('user://accounts/' . $username . YAML_EXT, true, true));
+        $file = CompiledYamlFile::instance(Grav::instance()['locator']->findResource('account://' . $username . YAML_EXT, true, true));
         $user->file($file);
         $user->save();
 
@@ -240,7 +240,7 @@ class NewUserCommand extends ConsoleCommand
                 if (!preg_match('/^[a-z0-9_-]{3,16}$/', $value)) {
                     throw new \RuntimeException('Username should be between 3 and 16 characters, including lowercase letters, numbers, underscores, and hyphens. Uppercase letters, spaces, and special characters are not allowed');
                 }
-                if (file_exists(Grav::instance()['locator']->findResource('user://accounts/' . $value . YAML_EXT))) {
+                if (file_exists(Grav::instance()['locator']->findResource('account://' . $value . YAML_EXT))) {
                     throw new \RuntimeException('Username "' . $value . '" already exists, please pick another username');
                 }
 

--- a/login.php
+++ b/login.php
@@ -544,7 +544,7 @@ class LoginPlugin extends Plugin
         $username = $form->value('username');
         $data['username'] = $username;
 
-        if (file_exists($this->grav['locator']->findResource('user://accounts/' . $username . YAML_EXT))) {
+        if (file_exists($this->grav['locator']->findResource('account://' . $username . YAML_EXT))) {
             $this->grav->fireEvent('onFormValidationError', new Event([
                 'form'    => $form,
                 'message' => $this->grav['language']->translate([


### PR DESCRIPTION
Issue #84

This change uses the stream wrapper (account://) that already exists in core for the accounts path rather than hard coding it to user://accounts/. This allows the user to override that stream in /user/config/streams.yaml and place the accounts in a directory outside the webroot.
