### PR TITLE
Add form name to the register template page

### DIFF
--- a/pages/register.md
+++ b/pages/register.md
@@ -1,5 +1,6 @@
 ---
 form:
+  name: register
   fields:
     -
       name: username


### PR DESCRIPTION
Added a "name" tag for the form on the register template page, since the form isn't displayed without this name tag. This behaviour is in place since Forms 2.0, see: https://learn.getgrav.org/forms/forms