### PR TITLE
Grav plugin cli error on password change

### DIFF
--- a/cli/ChangePasswordCommand.php
+++ b/cli/ChangePasswordCommand.php
@@ -2,6 +2,7 @@
 namespace Grav\Plugin\Console;
 
 use Grav\Console\ConsoleCommand;
+use Grav\Common\Grav;
 use Grav\Common\File\CompiledYamlFile;
 use Grav\Common\User\User;
 use Symfony\Component\Console\Input\InputOption;


### PR DESCRIPTION
The grav plugin cli tool throws an error when changing the passwd because it can't find the Grav class. Adding a use statement to the class fixed the issue. Submitting back in case it's a bug.