### PR TITLE
Cli commands were ignoring desired username

### DIFF
--- a/cli/ChangePasswordCommand.php
+++ b/cli/ChangePasswordCommand.php
@@ -92,7 +92,7 @@ class ChangePasswordCommand extends ConsoleCommand
                     throw new \RuntimeException('Username "' . $value . '" does not exist, please pick another username');
                 };
 
-                return true;
+                return $value;
             });
 
             $username = $helper->ask($this->input, $this->output, $question);

--- a/cli/ChangeUserStateCommand.php
+++ b/cli/ChangeUserStateCommand.php
@@ -92,7 +92,7 @@ class ChangeUserStateCommand extends ConsoleCommand
                     throw new \RuntimeException('Username "' . $value . '" does not exist, please pick another username');
                 };
 
-                return true;
+                return $value;
             });
 
             $username = $helper->ask($this->input, $this->output, $question);


### PR DESCRIPTION
This follows with the same fix applied to NewUserCommand for the ChangePasswordCommand and ChangeUserStateCommand