### PR TITLE
Fix uppercase and Unicode username handling

### DIFF
--- a/classes/Login.php
+++ b/classes/Login.php
@@ -230,7 +230,7 @@ class Login
 
         $username = $this->validateField('username', $data['username']);
 
-        $file = CompiledYamlFile::instance($this->grav['locator']->findResource('account://' . $username . YAML_EXT,
+        $file = CompiledYamlFile::instance($this->grav['locator']->findResource('account://' . mb_strtolower($username) . YAML_EXT,
             true, true));
 
         // Create user object and save it

--- a/cli/ChangePasswordCommand.php
+++ b/cli/ChangePasswordCommand.php
@@ -118,7 +118,7 @@ class ChangePasswordCommand extends ConsoleCommand
         }
 
         // Lowercase the username for the filename
-        $username = strtolower($username);
+        $username = mb_strtolower($username);
 
         /** @var UniformResourceLocator $locator */
         $locator = Grav::instance()['locator'];

--- a/cli/ChangeUserStateCommand.php
+++ b/cli/ChangeUserStateCommand.php
@@ -116,7 +116,7 @@ class ChangeUserStateCommand extends ConsoleCommand
         }
 
         // Lowercase the username for the filename
-        $username = strtolower($username);
+        $username = mb_strtolower($username);
 
         /** @var UniformResourceLocator $locator */
         $locator = Grav::instance()['locator'];

--- a/cli/NewUserCommand.php
+++ b/cli/NewUserCommand.php
@@ -131,9 +131,9 @@ class NewUserCommand extends ConsoleCommand
                 return $value;
             });
 
-            $username = $helper->ask($this->input, $this->output, $question);
+            $data['username'] = $helper->ask($this->input, $this->output, $question);
         } else {
-            $username = $this->options['user'];
+            $data['username'] = $this->options['user'];
         }
 
 
@@ -227,7 +227,7 @@ class NewUserCommand extends ConsoleCommand
         }
 
         // Lowercase the username for the filename
-        $username = strtolower($username);
+        $username = mb_strtolower($data['username']);
 
         /** @var UniformResourceLocator $locator */
         $locator = Grav::instance()['locator'];


### PR DESCRIPTION
Per getgrav/grav#2160, this is a pull request that improves how the users who decide to add some nice uppercase Cyrillic letters to their usernames are handled by the login plugin itself.

It includes a few patches to the plugin's CLI in order to add uppercase and Unicode username support to it, as well as a fix to the issue of the username filenames not being forced lowercase on registration.