### PR TITLE
Multi language site with login plugin redirect always to the default language

### DIFF
--- a/classes/Controller.php
+++ b/classes/Controller.php
@@ -381,7 +381,7 @@ class Controller
                 if ($good_token === $token) {
                     if (time() > $expire) {
                         $messages->add($language->translate('PLUGIN_LOGIN.RESET_LINK_EXPIRED'), 'error');
-                        $this->grav->redirect($this->grav['config']->get('plugins.login.route_forgot', '/'));
+                        $this->grav->redirectLangSafe($this->grav['config']->get('plugins.login.route_forgot', '/'));
 
                         return true;
                     }
@@ -401,7 +401,7 @@ class Controller
             }
 
             $messages->add($language->translate('PLUGIN_LOGIN.RESET_INVALID_LINK'), 'error');
-            $this->grav->redirect($this->grav['config']->get('plugins.login.route_forgot'));
+            $this->grav->redirectLangSafe($this->grav['config']->get('plugins.login.route_forgot'));
 
             return true;
 
@@ -412,7 +412,7 @@ class Controller
 
         if (!$user || !$token) {
             $messages->add($language->translate('PLUGIN_LOGIN.RESET_INVALID_LINK'), 'error');
-            $this->grav->redirect($this->grav['config']->get('plugins.login.route_forgot'));
+            $this->grav->redirectLangSafe($this->grav['config']->get('plugins.login.route_forgot'));
 
             return true;
         }

--- a/classes/Controller.php
+++ b/classes/Controller.php
@@ -335,7 +335,13 @@ class Controller
         $author = $this->grav['config']->get('site.author.name', '');
         $fullname = $user->fullname ?: $user->username;
 
-        $reset_link = $this->grav['base_url_absolute'] . $this->grav['config']->get('plugins.login.route_reset') . '/task:login.reset/token' . $param_sep . $token . '/user' . $param_sep . $user->username . '/nonce' . $param_sep . Utils::getNonce('reset-form');
+        if ($this->grav['language']->getDefault() != $this->grav['language']->getLanguage()) {
+            $lang = '/'.$this->grav['language']->getLanguage();
+        } else {
+            $lang = '';
+        }
+
+        $reset_link = $this->grav['base_url_absolute'] . $lang . $this->grav['config']->get('plugins.login.route_reset') . '/task:login.reset/token' . $param_sep . $token . '/user' . $param_sep . $user->username . '/nonce' . $param_sep . Utils::getNonce('reset-form');
 
         $sitename = $this->grav['config']->get('site.title', 'Website');
 

--- a/classes/Login.php
+++ b/classes/Login.php
@@ -196,7 +196,7 @@ class Login
         }
 
         if ($redirect) {
-            $this->grav->redirect($redirect, $event->getRedirectCode());
+            $this->grav->redirectLangSafe($redirect, $event->getRedirectCode());
         }
 
         return $user->authenticated && $user->authorized;

--- a/login.php
+++ b/login.php
@@ -407,7 +407,7 @@ class LoginPlugin extends Plugin
             }
         }
 
-        $this->grav->redirect($redirect_route ?: '/', $redirect_code);
+        $this->grav->redirectLangSafe($redirect_route ?: '/', $redirect_code);
     }
 
     /**
@@ -537,7 +537,7 @@ class LoginPlugin extends Plugin
 
         // User is not logged in; redirect to login page.
         if ($this->redirect_to_login && $this->route && !$authorized) {
-            $this->grav->redirect($this->route, 302);
+            $this->grav->redirectLangSafe($this->route, 302);
         }
 
         /** @var Twig $twig */
@@ -774,7 +774,7 @@ class LoginPlugin extends Plugin
         }
 
         if ($redirect) {
-            $this->grav->redirect($redirect, $redirect_code);
+            $this->grav->redirectLangSafe($redirect, $redirect_code);
         }
     }
 


### PR DESCRIPTION
Fix redirect on pages in different languages to stay in the current language. Fix the link in the email send to you wile resetting the password to go back to the same language of the page.