### PR TITLE
Correct sendNotificationEmail to use plugins.email.to

### DIFF
--- a/classes/Login.php
+++ b/classes/Login.php
@@ -338,7 +338,7 @@ class Login
             $user->email,
             $this->grav['base_url_absolute'],
         ]);
-        $to = $this->config->get('plugins.email.from');
+        $to = $this->config->get('plugins.email.to');
 
         if (empty($to)) {
             throw new \RuntimeException($this->language->translate('PLUGIN_LOGIN.EMAIL_NOT_CONFIGURED'));


### PR DESCRIPTION
Per the send_notification_email help text. The notification email should be sent to the email configured in the 'To' field in the email plugin.