### PR TITLE
enable bruteforce protection by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,10 +161,10 @@ rememberme:
   timeout: 604800                           # Timeout in seconds. Defaults to 1 week
   name: grav-rememberme                     # Name prefix of the session cookie
 
-max_pw_resets_count: 0                      # Number of password resets in a specific time frame (0 = unlimited)
+max_pw_resets_count: 2                      # Number of password resets in a specific time frame (0 = unlimited)
 max_pw_resets_interval: 60                  # Time in minutes to track password resets
-max_login_count: 0                          # Number of failed login attempts in a specific time frame (0 = unlimited)
-max_login_interval: 2                       # Time in minutes to track login attempts
+max_login_count: 5                          # Number of failed login attempts in a specific time frame (0 = unlimited)
+max_login_interval: 10                      # Time in minutes to track login attempts
 
 user_registration:
   enabled: false                            # Enable User Registration Process

--- a/classes/Login.php
+++ b/classes/Login.php
@@ -508,8 +508,8 @@ class Login
                     $interval = $this->grav['config']->get('plugins.login.max_login_interval', 10);
                     break;
                 case 'pw_resets':
-                    $maxCount = $this->grav['config']->get('plugins.login.max_pw_resets_count', 0);
-                    $interval = $this->grav['config']->get('plugins.login.max_pw_resets_interval', 2);
+                    $maxCount = $this->grav['config']->get('plugins.login.max_pw_resets_count', 2);
+                    $interval = $this->grav['config']->get('plugins.login.max_pw_resets_interval', 60);
                     break;
             }
             $this->rateLimiters[$context] = new RateLimiter($context, $maxCount, $interval);

--- a/login.yaml
+++ b/login.yaml
@@ -20,10 +20,10 @@ rememberme:
   timeout: 604800                           # Timeout in seconds. Defaults to 1 week
   name: grav-rememberme                     # Name prefix of the session cookie
 
-max_pw_resets_count: 0                      # Number of password resets in a specific time frame (0 = unlimited)
+max_pw_resets_count: 2                      # Number of password resets in a specific time frame (0 = unlimited)
 max_pw_resets_interval: 60                  # Time in minutes to track password resets
-max_login_count: 0                          # Number of failed login attempts in a specific time frame (0 = unlimited)
-max_login_interval: 2                       # Time in minutes to track login attempts
+max_login_count: 5                          # Number of failed login attempts in a specific time frame (0 = unlimited)
+max_login_interval: 10                      # Time in minutes to track login attempts
 
 user_registration:
   enabled: false                            # Enable User Registration Process


### PR DESCRIPTION
There were different values in the code, now values equal.

According to security by default bruteforce protection should be enabled by default.

`max_pw_resets_count` should be set, otherwise it can be used to spam victims mail address with reset mails.