### PR TITLE
include hide_git_sync_repo_link

### DIFF
--- a/pages/login.md
+++ b/pages/login.md
@@ -1,6 +1,8 @@
 ---
 title: Login
 
+hide_git_sync_repo_link: true
+
 login_redirect_here: false
 
 forms:


### PR DESCRIPTION
resquesting to have/respect the option to hide_git_sync_repo_link: true, I think it could be a selection in the config pluggin.