### PR TITLE
Issue #277 Add cli option for language

### DIFF
--- a/classes/Login.php
+++ b/classes/Login.php
@@ -15,6 +15,7 @@ use Grav\Common\Data\Data;
 use Grav\Common\Debugger;
 use Grav\Common\Grav;
 use Grav\Common\Language\Language;
+use Grav\Common\Language\LanguageCodes;
 use Grav\Common\Page\Interfaces\PageInterface;
 use Grav\Common\Page\Page;
 use Grav\Common\Page\Pages;
@@ -418,6 +419,13 @@ class Login
 
                 break;
 
+            case 'language':
+                $languages = new LanguageCodes();
+                if ($value !== null && !array_key_exists($value, $languages->getList())) {
+                    throw new \RuntimeException('Language code is not valid');
+                }
+
+                break;
         }
 
         return $value;

--- a/cli/NewUserCommand.php
+++ b/cli/NewUserCommand.php
@@ -56,6 +56,12 @@ class NewUserCommand extends ConsoleCommand
                 'The user email'
             )
             ->addOption(
+                'language',
+                'l',
+                InputOption::VALUE_OPTIONAL,
+                'The default language of the account. [default: "en"]'
+            )
+            ->addOption(
                 'permissions',
                 'P',
                 InputOption::VALUE_REQUIRED,
@@ -101,6 +107,7 @@ class NewUserCommand extends ConsoleCommand
             'user'        => $this->input->getOption('user'),
             'password1'   => $this->input->getOption('password'),
             'email'       => $this->input->getOption('email'),
+            'language'    => $this->input->getOption('language'),
             'permissions' => $this->input->getOption('permissions'),
             'fullname'    => $this->input->getOption('fullname'),
             'title'       => $this->input->getOption('title'),
@@ -168,6 +175,21 @@ class NewUserCommand extends ConsoleCommand
             $user->set('email', $helper->ask($this->input, $this->output, $question));
         } else {
             $user->set('email', $this->options['email']);
+        }
+
+        if (!$this->options['language']) {
+            // Get language and validate.
+            $question = new Question('Enter a <yellow>language abbreviation</yellow> [en]:   ');
+            $question->setValidator(function ($value) {
+                return $this->validate('language', $value);
+            });
+
+            $user->set('language', $helper->ask($this->input, $this->output, $question));
+            if ($user->get('language') == null) {
+                $user->set('language', 'en');
+            }
+        } else {
+            $user->set('language', $this->options['language']);
         }
 
         if (!$this->options['permissions']) {


### PR DESCRIPTION
Adds an option (`-l` or `--language=XX`) for adding a custom language code to the user during user creation via the CLI.