### PR TITLE
fix Prevent session fixation only if initialize session is enabled

### DIFF
--- a/login.php
+++ b/login.php
@@ -1272,7 +1272,9 @@ class LoginPlugin extends Plugin
         $session = $this->grav['session'];
 
         // Prevent session fixation.
-        $session->regenerateId();
+        if ($this->config->get('system.session.initialize', true)) {
+            $session->regenerateId();
+        }
 
         $session->user = $user = $event->getUser();
 


### PR DESCRIPTION
The `$session->regenerateId()` method must not be called if session initialization is disabled.
It is up to the plugin to eventually do this.