### PR TITLE
Add multipart login emails with text/plain alternatives

### DIFF
--- a/classes/Email.php
+++ b/classes/Email.php
@@ -318,11 +318,12 @@ class Email
 
     protected static function templateExists(string $template): bool
     {
-        $twig = Grav::instance()['twig'];
-        $twig->init();
-
         try {
+            $twig = Grav::instance()['twig'];
+            $twig->init();
+
             $loader = $twig->twig()->getLoader();
+
             return method_exists($loader, 'exists') ? $loader->exists($template) : false;
         } catch (\Throwable $e) {
             return false;

--- a/classes/Email.php
+++ b/classes/Email.php
@@ -235,10 +235,25 @@ class Email
             'author' => $config->get('site.author.name', ''),
         ];
 
-        $params += [
-            'body' => '',
-            'template' => "emails/login/{$template}.html.twig",
-        ];
+        if (!isset($params['body']) && !isset($params['template'])) {
+            $body = [
+                [
+                    'content_type' => 'text/html',
+                    'template' => "emails/login/{$template}.html.twig",
+                    'body' => '',
+                ],
+            ];
+
+            if (static::templateExists("emails/login/{$template}.txt.twig")) {
+                $body[] = [
+                    'content_type' => 'text/plain',
+                    'template' => "emails/login/{$template}.txt.twig",
+                    'body' => '',
+                ];
+            }
+
+            $params['body'] = $body;
+        }
 
         $email = static::getEmail();
 
@@ -299,5 +314,18 @@ class Email
     protected static function getLanguage(): Language
     {
         return Grav::instance()['language'];
+    }
+
+    protected static function templateExists(string $template): bool
+    {
+        $twig = Grav::instance()['twig'];
+        $twig->init();
+
+        try {
+            $loader = $twig->twig()->getLoader();
+            return method_exists($loader, 'exists') ? $loader->exists($template) : false;
+        } catch (\Throwable $e) {
+            return false;
+        }
     }
 }

--- a/templates/emails/login/_text-utils.txt.twig
+++ b/templates/emails/login/_text-utils.txt.twig
@@ -1,0 +1,29 @@
+{# Utilities for plain text login emails #}
+{%- macro from_html(content) -%}
+{{- content
+    |replace({
+        '<br>': "\n",
+        '<br/>': "\n",
+        '<br />': "\n",
+        '<p>': '',
+        '</p>': "\n\n",
+        '<h1>': '',
+        '<h2>': '',
+        '<h3>': '',
+        '</h1>': "\n\n",
+        '</h2>': "\n\n",
+        '</h3>': "\n\n",
+        '<ul>': "\n",
+        '</ul>': "\n",
+        '<ol>': "\n",
+        '</ol>': "\n",
+        '<li>': ' * ',
+        '</li>': "\n",
+        '<div>': '',
+        '</div>': "\n\n",
+        '&nbsp;': ' '
+    })
+    |striptags
+    |trim
+-}}
+{%- endmacro -%}

--- a/templates/emails/login/activate.txt.twig
+++ b/templates/emails/login/activate.txt.twig
@@ -1,0 +1,8 @@
+{# Activation email (plain text) #}
+{%- set subject = 'PLUGIN_LOGIN.ACTIVATION_EMAIL_SUBJECT'|t(site_name) -%}
+{%- do email.message.setSubject(subject) -%}
+{{ 'PLUGIN_LOGIN.HOST_WARNING'|t(site_host)|striptags|trim }}
+
+{{ 'PLUGIN_LOGIN.ACTIVATION_EMAIL_BODY'|t(user.fullname, activation_link, site_name, author)|striptags|trim }}
+
+{{ activation_link }}

--- a/templates/emails/login/activate.txt.twig
+++ b/templates/emails/login/activate.txt.twig
@@ -1,8 +1,9 @@
 {# Activation email (plain text) #}
+{%- import 'emails/login/_text-utils.txt.twig' as text -%}
 {%- set subject = 'PLUGIN_LOGIN.ACTIVATION_EMAIL_SUBJECT'|t(site_name) -%}
 {%- do email.message.setSubject(subject) -%}
-{{ 'PLUGIN_LOGIN.HOST_WARNING'|t(site_host)|striptags|trim }}
+{{ text.from_html('PLUGIN_LOGIN.HOST_WARNING'|t(site_host)) }}
 
-{{ 'PLUGIN_LOGIN.ACTIVATION_EMAIL_BODY'|t(user.fullname, activation_link, site_name, author)|striptags|trim }}
+{{ text.from_html('PLUGIN_LOGIN.ACTIVATION_EMAIL_BODY'|t(user.fullname, activation_link, site_name, author)) }}
 
 {{ activation_link }}

--- a/templates/emails/login/invite.txt.twig
+++ b/templates/emails/login/invite.txt.twig
@@ -1,7 +1,8 @@
 {# Invitation email (plain text) #}
+{%- import 'emails/login/_text-utils.txt.twig' as text -%}
 {%- set subject = 'PLUGIN_LOGIN.INVITATION_EMAIL_SUBJECT'|t(site_name) -%}
 {%- set message = message ?? 'PLUGIN_LOGIN.INVITATION_EMAIL_MESSAGE'|t -%}
 {%- do email.message.setSubject(subject) -%}
-{{ 'PLUGIN_LOGIN.INVITATION_EMAIL_BODY'|t(site_name, message, invitation_link, actor.fullname)|striptags|trim }}
+{{ text.from_html('PLUGIN_LOGIN.INVITATION_EMAIL_BODY'|t(site_name, message, invitation_link, actor.fullname)) }}
 
 {{ invitation_link }}

--- a/templates/emails/login/invite.txt.twig
+++ b/templates/emails/login/invite.txt.twig
@@ -1,0 +1,7 @@
+{# Invitation email (plain text) #}
+{%- set subject = 'PLUGIN_LOGIN.INVITATION_EMAIL_SUBJECT'|t(site_name) -%}
+{%- set message = message ?? 'PLUGIN_LOGIN.INVITATION_EMAIL_MESSAGE'|t -%}
+{%- do email.message.setSubject(subject) -%}
+{{ 'PLUGIN_LOGIN.INVITATION_EMAIL_BODY'|t(site_name, message, invitation_link, actor.fullname)|striptags|trim }}
+
+{{ invitation_link }}

--- a/templates/emails/login/notification.txt.twig
+++ b/templates/emails/login/notification.txt.twig
@@ -1,0 +1,6 @@
+{# Notification email (plain text) #}
+{%- set subject = 'PLUGIN_LOGIN.NOTIFICATION_EMAIL_SUBJECT'|t(site_name) -%}
+{%- do email.message.setSubject(subject) -%}
+{{ 'PLUGIN_LOGIN.NOTIFICATION_EMAIL_BODY'|t(site_name, user.username, user.email, base_url_absolute)|striptags|trim }}
+
+{{ base_url_absolute }}

--- a/templates/emails/login/notification.txt.twig
+++ b/templates/emails/login/notification.txt.twig
@@ -1,6 +1,7 @@
 {# Notification email (plain text) #}
+{%- import 'emails/login/_text-utils.txt.twig' as text -%}
 {%- set subject = 'PLUGIN_LOGIN.NOTIFICATION_EMAIL_SUBJECT'|t(site_name) -%}
 {%- do email.message.setSubject(subject) -%}
-{{ 'PLUGIN_LOGIN.NOTIFICATION_EMAIL_BODY'|t(site_name, user.username, user.email, base_url_absolute)|striptags|trim }}
+{{ text.from_html('PLUGIN_LOGIN.NOTIFICATION_EMAIL_BODY'|t(site_name, user.username, user.email, base_url_absolute)) }}
 
 {{ base_url_absolute }}

--- a/templates/emails/login/reset-password.txt.twig
+++ b/templates/emails/login/reset-password.txt.twig
@@ -1,8 +1,9 @@
 {# Reset password email (plain text) #}
+{%- import 'emails/login/_text-utils.txt.twig' as text -%}
 {%- set subject = 'PLUGIN_LOGIN.FORGOT_EMAIL_SUBJECT'|t(site_name) -%}
 {%- do email.message.setSubject(subject) -%}
-{{ 'PLUGIN_LOGIN.HOST_WARNING'|t(site_host)|striptags|trim }}
+{{ text.from_html('PLUGIN_LOGIN.HOST_WARNING'|t(site_host)) }}
 
-{{ 'PLUGIN_LOGIN.FORGOT_EMAIL_BODY'|t(user.fullname ?? user.username, reset_link, author, site_name)|striptags|trim }}
+{{ text.from_html('PLUGIN_LOGIN.FORGOT_EMAIL_BODY'|t(user.fullname ?? user.username, reset_link, author, site_name)) }}
 
 {{ reset_link }}

--- a/templates/emails/login/reset-password.txt.twig
+++ b/templates/emails/login/reset-password.txt.twig
@@ -1,0 +1,8 @@
+{# Reset password email (plain text) #}
+{%- set subject = 'PLUGIN_LOGIN.FORGOT_EMAIL_SUBJECT'|t(site_name) -%}
+{%- do email.message.setSubject(subject) -%}
+{{ 'PLUGIN_LOGIN.HOST_WARNING'|t(site_host)|striptags|trim }}
+
+{{ 'PLUGIN_LOGIN.FORGOT_EMAIL_BODY'|t(user.fullname ?? user.username, reset_link, author, site_name)|striptags|trim }}
+
+{{ reset_link }}

--- a/templates/emails/login/welcome.txt.twig
+++ b/templates/emails/login/welcome.txt.twig
@@ -1,6 +1,7 @@
 {# Welcome email (plain text) #}
+{%- import 'emails/login/_text-utils.txt.twig' as text -%}
 {%- set subject = 'PLUGIN_LOGIN.WELCOME_EMAIL_SUBJECT'|t(site_name) -%}
 {%- do email.message.setSubject(subject) -%}
-{{ 'PLUGIN_LOGIN.WELCOME_EMAIL_BODY'|t(user.fullname ?? user.username, base_url_absolute, site_name, author)|striptags|trim }}
+{{ text.from_html('PLUGIN_LOGIN.WELCOME_EMAIL_BODY'|t(user.fullname ?? user.username, base_url_absolute, site_name, author)) }}
 
 {{ base_url_absolute }}

--- a/templates/emails/login/welcome.txt.twig
+++ b/templates/emails/login/welcome.txt.twig
@@ -1,0 +1,6 @@
+{# Welcome email (plain text) #}
+{%- set subject = 'PLUGIN_LOGIN.WELCOME_EMAIL_SUBJECT'|t(site_name) -%}
+{%- do email.message.setSubject(subject) -%}
+{{ 'PLUGIN_LOGIN.WELCOME_EMAIL_BODY'|t(user.fullname ?? user.username, base_url_absolute, site_name, author)|striptags|trim }}
+
+{{ base_url_absolute }}


### PR DESCRIPTION
## Summary
This PR adds proper multipart email support to the Login plugin by sending both HTML and plain-text parts for login-related emails.

## Why
Some mail clients and filters handle HTML-only emails poorly. Adding a `text/plain` alternative improves compatibility, accessibility, and reliability (especially for activation/reset flows where the raw URL is important).

## What changed
1. Updated `classes/Email.php`:
- replaced default single-template setup with multipart body assembly;
- keeps HTML template as primary part;
- automatically adds a plain-text part if a matching `emails/login/<template>.txt.twig` exists;
- added a small `templateExists()` helper using Twig loader.

2. Added plain-text templates:
- `templates/emails/login/activate.txt.twig`
- `templates/emails/login/reset-password.txt.twig`
- `templates/emails/login/welcome.txt.twig`
- `templates/emails/login/notification.txt.twig`
- `templates/emails/login/invite.txt.twig`

Each template reuses existing translation keys/context and includes the direct action link as plain text.

## Backward compatibility
- If no `.txt.twig` exists for a template, behavior remains HTML-only.
- Existing HTML templates and email subjects are unchanged.

## Notes
This change is intentionally minimal and limited to login email composition/templates only.
