### PR TITLE
Add plain-text magic login email template

### DIFF
--- a/templates/emails/login/magic-login.txt.twig
+++ b/templates/emails/login/magic-login.txt.twig
@@ -1,0 +1,8 @@
+{# Magic login email (plain text) #}
+{%- import 'emails/login/_text-utils.txt.twig' as text -%}
+{%- set subject = 'PLUGIN_LOGIN.MAGIC_LOGIN_EMAIL_SUBJECT'|t(site_name) -%}
+{%- set message = message ?? 'PLUGIN_LOGIN.MAGIC_LOGIN_EMAIL_MESSAGE'|t -%}
+{%- do email.message.setSubject(subject) -%}
+{{ text.from_html('PLUGIN_LOGIN.MAGIC_LOGIN_EMAIL_BODY'|t(site_name, message, login_link, author)) }}
+
+{{ login_link }}


### PR DESCRIPTION
This is a small follow-up after #325 and #326.

It adds a plain-text `magic-login.txt.twig` template now that multipart/plain-text email support is available in `develop`.

The template reuses the shared `_text-utils.txt.twig` helper and keeps the explicit `{{ login_link }}` fallback at the end, consistent with the other login email text templates.